### PR TITLE
Add ability to generate automatic ARM images

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,6 +1,8 @@
 FROM resin/rpi-raspbian:stretch
 MAINTAINER Kristian Haugene
 
+RUN [ "cross-build-start" ]
+
 VOLUME /data
 VOLUME /config
 
@@ -123,3 +125,5 @@ ENV OPENVPN_USERNAME=**None** \
 # Expose port and run
 EXPOSE 9091
 CMD ["dumb-init", "/etc/openvpn/start.sh"]
+
+RUN [ "cross-build-end" ]

--- a/proxy/Dockerfile.armhf
+++ b/proxy/Dockerfile.armhf
@@ -1,5 +1,7 @@
 FROM resin/rpi-raspbian:stretch
 
+RUN [ "cross-build-start" ]
+
 RUN apt-get update \
       && apt-get install -y \
         ca-certificates \
@@ -15,3 +17,4 @@ COPY nginx.conf /etc/nginx/nginx.conf
 
 CMD ["nginx", "-g", "daemon off;"]
 
+RUN [ "cross-build-end" ]


### PR DESCRIPTION
[Building ARM containers on any x86 machine, even DockerHub](https://resin.io/blog/building-arm-containers-on-any-x86-machine-even-dockerhub/)